### PR TITLE
update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ Multiple resolvers or hosts can be separated by spaces and/or commas. Specify an
 
 You can grab the latest release from the [release page](https://github.com/mowings/rpounder/releases), unarchive,  and merely copy the correct binary somewhere on your path. There are no dependencies.
 
+or 
+
+you can run :
+
+```shell
+go get github.com/mowings/rpounder/src/rpounder
+```
+
 ## Building it
 
 You'll need go 1.7 or better. I use [gb](https://getgb.io/) to build, in which case you can simply change to the project directory and run `gb build`. 


### PR DESCRIPTION
running "go get <package>" also runs build and install so it should install the binary in your $GOPATH/bin or $GOBIN
I find this method much more easy and straight forward